### PR TITLE
feat: Support use of track_latest for task definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ module "ecs" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,10 +134,14 @@ Since Terraform does not support variables within `lifecycle {}` blocks, its not
     # task definition changes, and still allowing an external party to modify the image/tag
     # without conflicting with Terraform
     ignore_task_definition_changes = false
+
+    # This ensures that aws_ecs_task_definition matches the most recent active task
+    # definition, even if it was externally created.
+    task_definition_track_latest = true
   }
   ```
 
-This could be expanded further to include the entire container definitions argument, provided that external party making changes to the container definitions provides a copy that Terraform can retrieve and use when making updates to task definitions. This is possible due to the use of the `aws_ecs_task_definition` data source in the module - the data source retrieves the task definition currently defined in AWS. Using the `max()` function in Terraform, we can get the latest version via `max(aws_ecs_task_definition.this[0].revision, data.aws_ecs_task_definition.this[0].revision)` and use that as the `task_definition` value through reconstructing the `family:revision` format such as `"${aws_ecs_task_definition.this[0].family}:${local.max_task_def_revision}"`. With this work around, any changes made by Terraform would result in a new task definition revision resulting in Terraform updating the revision and deploying that change into the cluster. Likewise, any external party making changes to the task definition will increment the revision and deploy that into the cluster. Provided that Terraform can refer to the same values of the arguments changed by the external party, Terraform will be able to have a complete view of the current status and only make changes when necessary, without conflicting with the external party.
+This could be expanded further to include the entire container definitions argument, provided that external party making changes to the container definitions provides a copy that Terraform can retrieve and use when making updates to task definitions. With this work around, any changes made by Terraform would result in a new task definition revision resulting in Terraform updating the revision and deploying that change into the cluster. Likewise, any external party making changes to the task definition will increment the revision and deploy that into the cluster. Provided that Terraform can refer to the same values of the arguments changed by the external party, Terraform will be able to have a complete view of the current status and only make changes when necessary, without conflicting with the external party.
 
 <p align="center">
   <img src="./images/service.png" alt="ECS Service" width="40%">

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/examples/ec2-autoscaling/README.md
+++ b/examples/ec2-autoscaling/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/examples/ec2-autoscaling/versions.tf
+++ b/examples/ec2-autoscaling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/examples/fargate/versions.tf
+++ b/examples/fargate/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,8 @@ module "service" {
 
   # Task definition
   create_task_definition        = try(each.value.create_task_definition, true)
-  task_definition_arn           = lookup(each.value, "task_definition_arn", null)
+  task_definition_arn           = try(each.value.task_definition_arn, null)
+  task_definition_track_latest  = try(each.value.task_definition_track_latest, false)
   container_definitions         = try(each.value.container_definitions, {})
   container_definition_defaults = try(each.value.container_definition_defaults, {})
   cpu                           = try(each.value.cpu, 1024)

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ module "service" {
   # Task definition
   create_task_definition        = try(each.value.create_task_definition, true)
   task_definition_arn           = try(each.value.task_definition_arn, null)
-  task_definition_track_latest  = try(each.value.task_definition_track_latest, false)
+  task_definition_track_latest  = try(each.value.task_definition_track_latest, true)
   container_definitions         = try(each.value.container_definitions, {})
   container_definition_defaults = try(each.value.container_definition_defaults, {})
   cpu                           = try(each.value.cpu, 1024)

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -135,13 +135,13 @@ module "ecs_cluster" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/modules/container-definition/README.md
+++ b/modules/container-definition/README.md
@@ -116,13 +116,13 @@ module "example_ecs_container_definition" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/modules/container-definition/versions.tf
+++ b/modules/container-definition/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -167,13 +167,13 @@ module "ecs_service" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -206,7 +206,6 @@ module "ecs_service" {
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
 | [aws_iam_policy_document.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.service_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -294,6 +293,7 @@ module "ecs_service" {
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_task_definition_arn"></a> [task\_definition\_arn](#input\_task\_definition\_arn) | Existing task definition ARN. Required when `create_task_definition` is `false` | `string` | `null` | no |
 | <a name="input_task_definition_placement_constraints"></a> [task\_definition\_placement\_constraints](#input\_task\_definition\_placement\_constraints) | Configuration block for rules that are taken into consideration during task placement (up to max of 10). This is set at the task definition, see `placement_constraints` for setting at the service | `any` | `{}` | no |
+| <a name="input_task_definition_track_latest"></a> [task\_definition\_track\_latest](#input\_task\_definition\_track\_latest) | Track latest task definition revision in case of external changes | `bool` | `false` | no |
 | <a name="input_task_exec_iam_policy_path"></a> [task\_exec\_iam\_policy\_path](#input\_task\_exec\_iam\_policy\_path) | Path for the iam role | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_arn"></a> [task\_exec\_iam\_role\_arn](#input\_task\_exec\_iam\_role\_arn) | Existing IAM role ARN | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_description"></a> [task\_exec\_iam\_role\_description](#input\_task\_exec\_iam\_role\_description) | Description of the role | `string` | `null` | no |

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -293,7 +293,7 @@ module "ecs_service" {
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_task_definition_arn"></a> [task\_definition\_arn](#input\_task\_definition\_arn) | Existing task definition ARN. Required when `create_task_definition` is `false` | `string` | `null` | no |
 | <a name="input_task_definition_placement_constraints"></a> [task\_definition\_placement\_constraints](#input\_task\_definition\_placement\_constraints) | Configuration block for rules that are taken into consideration during task placement (up to max of 10). This is set at the task definition, see `placement_constraints` for setting at the service | `any` | `{}` | no |
-| <a name="input_task_definition_track_latest"></a> [task\_definition\_track\_latest](#input\_task\_definition\_track\_latest) | Track latest task definition revision in case of external changes | `bool` | `false` | no |
+| <a name="input_task_definition_track_latest"></a> [task\_definition\_track\_latest](#input\_task\_definition\_track\_latest) | Track latest task definition revision in case of external changes | `bool` | `true` | no |
 | <a name="input_task_exec_iam_policy_path"></a> [task\_exec\_iam\_policy\_path](#input\_task\_exec\_iam\_policy\_path) | Path for the iam role | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_arn"></a> [task\_exec\_iam\_role\_arn](#input\_task\_exec\_iam\_role\_arn) | Existing IAM role ARN | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_description"></a> [task\_exec\_iam\_role\_description](#input\_task\_exec\_iam\_role\_description) | Description of the role | `string` | `null` | no |

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -593,11 +593,9 @@ module "container_definition" {
 locals {
   create_task_definition = var.create && var.create_task_definition
 
-  # This allows us to query both the existing as well as Terraform's state and get
-  # and get the max version of either source, useful for when external resources
-  # update the container definition
-  max_task_def_revision = local.create_task_definition ? max(aws_ecs_task_definition.this[0].revision, data.aws_ecs_task_definition.this[0].revision) : 0
-  task_definition       = local.create_task_definition ? "${aws_ecs_task_definition.this[0].family}:${local.max_task_def_revision}" : var.task_definition_arn
+  # Enabling task_definition_track_latest is recommended, to make sure
+  # aws_ecs_task_definition represents the most recent active task definition.
+  task_definition = local.create_task_definition ? "${aws_ecs_task_definition.this[0].family}:${aws_ecs_task_definition.this[0].revision}" : var.task_definition_arn
 }
 
 # This allows us to query both the existing as well as Terraform's state and get
@@ -737,6 +735,8 @@ resource "aws_ecs_task_definition" "this" {
       name      = try(volume.value.name, volume.key)
     }
   }
+
+  track_latest = var.task_definition_track_latest
 
   tags = merge(var.tags, var.task_tags)
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -598,20 +598,6 @@ locals {
   task_definition = local.create_task_definition ? "${aws_ecs_task_definition.this[0].family}:${aws_ecs_task_definition.this[0].revision}" : var.task_definition_arn
 }
 
-# This allows us to query both the existing as well as Terraform's state and get
-# and get the max version of either source, useful for when external resources
-# update the container definition
-data "aws_ecs_task_definition" "this" {
-  count = local.create_task_definition ? 1 : 0
-
-  task_definition = aws_ecs_task_definition.this[0].family
-
-  depends_on = [
-    # Needs to exist first on first deployment
-    aws_ecs_task_definition.this
-  ]
-}
-
 resource "aws_ecs_task_definition" "this" {
   count = local.create_task_definition ? 1 : 0
 

--- a/modules/service/outputs.tf
+++ b/modules/service/outputs.tf
@@ -61,7 +61,7 @@ output "task_definition_family" {
 
 output "task_definition_family_revision" {
   description = "The family and revision (family:revision) of the task definition"
-  value       = "${try(aws_ecs_task_definition.this[0].family, "")}:${local.max_task_def_revision}"
+  value       = "${try(aws_ecs_task_definition.this[0].family, "")}:${try(aws_ecs_task_definition.this[0].revision, "")}"
 }
 
 ################################################################################

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -277,7 +277,7 @@ variable "task_definition_arn" {
 variable "task_definition_track_latest" {
   description = "Track latest task definition revision in case of external changes"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "container_definitions" {

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -274,6 +274,12 @@ variable "task_definition_arn" {
   default     = null
 }
 
+variable "task_definition_track_latest" {
+  description = "Track latest task definition revision in case of external changes"
+  type        = bool
+  default     = false
+}
+
 variable "container_definitions" {
   description = "A map of valid [container definitions](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html). Please note that you should only provide values that are part of the container definition document"
   type        = any

--- a/modules/service/versions.tf
+++ b/modules/service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/wrappers/cluster/versions.tf
+++ b/wrappers/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/wrappers/container-definition/versions.tf
+++ b/wrappers/container-definition/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/wrappers/service/main.tf
+++ b/wrappers/service/main.tf
@@ -98,7 +98,7 @@ module "wrapper" {
   tags                                    = try(each.value.tags, var.defaults.tags, {})
   task_definition_arn                     = try(each.value.task_definition_arn, var.defaults.task_definition_arn, null)
   task_definition_placement_constraints   = try(each.value.task_definition_placement_constraints, var.defaults.task_definition_placement_constraints, {})
-  task_definition_track_latest            = try(each.value.task_definition_track_latest, var.defaults.task_definition_track_latest, false)
+  task_definition_track_latest            = try(each.value.task_definition_track_latest, var.defaults.task_definition_track_latest, true)
   task_exec_iam_policy_path               = try(each.value.task_exec_iam_policy_path, var.defaults.task_exec_iam_policy_path, null)
   task_exec_iam_role_arn                  = try(each.value.task_exec_iam_role_arn, var.defaults.task_exec_iam_role_arn, null)
   task_exec_iam_role_description          = try(each.value.task_exec_iam_role_description, var.defaults.task_exec_iam_role_description, null)

--- a/wrappers/service/main.tf
+++ b/wrappers/service/main.tf
@@ -98,6 +98,7 @@ module "wrapper" {
   tags                                    = try(each.value.tags, var.defaults.tags, {})
   task_definition_arn                     = try(each.value.task_definition_arn, var.defaults.task_definition_arn, null)
   task_definition_placement_constraints   = try(each.value.task_definition_placement_constraints, var.defaults.task_definition_placement_constraints, {})
+  task_definition_track_latest            = try(each.value.task_definition_track_latest, var.defaults.task_definition_track_latest, false)
   task_exec_iam_policy_path               = try(each.value.task_exec_iam_policy_path, var.defaults.task_exec_iam_policy_path, null)
   task_exec_iam_role_arn                  = try(each.value.task_exec_iam_role_arn, var.defaults.task_exec_iam_role_arn, null)
   task_exec_iam_role_description          = try(each.value.task_exec_iam_role_description, var.defaults.task_exec_iam_role_description, null)

--- a/wrappers/service/versions.tf
+++ b/wrappers/service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.37"
     }
   }
 }


### PR DESCRIPTION
Make it possible to enable `track_latest` for `aws_ecs_task_definition` resources.

This is quite similar to https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/171.

Ref: DIS-11090